### PR TITLE
convert specs to RSpec3

### DIFF
--- a/spec/filepath_spec.rb
+++ b/spec/filepath_spec.rb
@@ -182,7 +182,7 @@ describe Filepath do
 		]
 		with_extension.each do |path|
 			it "says that <#{path}> has an extension" do
-				Filepath.new(path).extension?.should be_true
+				Filepath.new(path).extension?.should be true
 			end
 		end
 
@@ -193,7 +193,7 @@ describe Filepath do
 		]
 		no_extension.each do |path|
 			it "says that <#{path}> has no extension" do
-				Filepath.new(path).extension?.should be_false
+				Filepath.new(path).extension?.should be false
 			end
 		end
 
@@ -205,12 +205,12 @@ describe Filepath do
 		]
 		extension_data.each do |path, ext|
 			it "says that <#{path}> extesions is #{ext.inspect}" do
-				Filepath.new(path).extension?(ext).should be_true
+				Filepath.new(path).extension?(ext).should be true
 			end
 		end
 
 		it "says that `foo.bar` extension is not `baz`" do
-			Filepath.new('foo.bar').extension?('baz').should be_false
+			Filepath.new('foo.bar').extension?('baz').should be false
 		end
 	end
 
@@ -320,7 +320,7 @@ describe Filepath do
 				steps << seg
 			end
 
-			steps.should have(4).items
+			steps.size.should eq(4)
 			steps[0].should eq("/")
 			steps[1].should eq("a")
 			steps[2].should eq("b")
@@ -333,7 +333,7 @@ describe Filepath do
 				steps << seg
 			end
 
-			steps.should have(3).items
+			steps.size.should eq(3)
 			steps[0].should eq("a")
 			steps[1].should eq("b")
 			steps[2].should eq("c")
@@ -352,7 +352,7 @@ describe Filepath do
 				steps << seg
 			end
 
-			steps.should have(4).items
+			steps.size.should eq(4)
 			steps[0].should eq("/a/b/c")
 			steps[1].should eq("/a/b")
 			steps[2].should eq("/a")
@@ -365,7 +365,7 @@ describe Filepath do
 				steps << seg
 			end
 
-			steps.should have(3).items
+			steps.size.should eq(3)
 			steps[0].should eq("a/b/c")
 			steps[1].should eq("a/b")
 			steps[2].should eq("a")
@@ -384,7 +384,7 @@ describe Filepath do
 				steps << seg
 			end
 
-			steps.should have(4).items
+			steps.size.should eq(4)
 			steps[0].should eq("/")
 			steps[1].should eq("/a")
 			steps[2].should eq("/a/b")
@@ -397,7 +397,7 @@ describe Filepath do
 				steps << seg
 			end
 
-			steps.should have(3).items
+			steps.size.should eq(3)
 			steps[0].should eq("a")
 			steps[1].should eq("a/b")
 			steps[2].should eq("a/b/c")
@@ -801,7 +801,7 @@ describe Filepath do
 				ph.open('w') { |file| file << lines.join("\n") }
 				readlines = ph.readlines
 
-				readlines.should have(3).lines
+				readlines.size.should eq(3)
 				readlines.all? { |l| l.chomp.should == line }
 			end
 
@@ -811,7 +811,7 @@ describe Filepath do
 				ph.open('w') { |file| file << lines.join(sep) }
 				readlines = ph.readlines(sep)
 
-				readlines.should have(3).lines
+				readlines.size.should eq(3)
 				readlines[0..-2].all? { |l| l.should == line + sep}
 				readlines.last.should == line
 			end
@@ -964,68 +964,68 @@ describe Filepath do
 			it "finds all paths matching a glob string" do
 				list = @root.find('*1')
 
-				list.should have(8).items
+				list.size.should eq(8)
 				list.each { |path| path.should =~ /1/ }
 			end
 
 			it "finds all paths matching a Regex" do
 				list = @root.find(/2/)
 
-				list.should have(6).items
+				list.size.should eq(6)
 				list.each { |path| path.should =~ /2/ }
 			end
 
 			it "finds all paths for which the block returns true" do
 				list = @root.find { |path| path.directory? }
 
-				list.should have(9).items
+				list.size.should eq(9)
 				list.each { |path| path.filename.should =~ /^d/ }
 			end
 		end
 
 		describe "#files" do
 			it "finds 1 file in the root directory" do
-				@root.files.should have(1).item
+				@root.files.size.should eq(1)
 			end
 
 			it "finds 3 files in the root directory and its sub directories" do
-				@root.files(true).should have(3).item
+				@root.files(true).size.should eq(3)
 			end
 
 			it "finds 2 files in directory <d1>" do
-				(@root / 'd1').files.should have(2).items
+				(@root / 'd1').files.size.should eq(2)
 			end
 
 			it "finds no files in directory <d1/d12>" do
-				(@root / 'd1' / 'd12').files.should have(0).items
+				(@root / 'd1' / 'd12').files.size.should eq(0)
 			end
 		end
 
 		describe "#directories" do
 			it "finds 4 directories in the root directory" do
-				@root.directories.should have(4).items
+				@root.directories.size.should eq(4)
 			end
 
 			it "finds 9 directories in the root directory and its sub directories" do
-				@root.directories(true).should have(9).item
+				@root.directories(true).size.should eq(9)
 			end
 
 			it "finds 2 directories in directory <d2>" do
-				(@root / 'd2').directories.should have(2).items
+				(@root / 'd2').directories.size.should eq(2)
 			end
 
 			it "finds no directories in directory <d1/d13>" do
-				(@root / 'd1' / 'd13').directories.should have(0).items
+				(@root / 'd1' / 'd13').directories.size.should eq(0)
 			end
 		end
 
 		describe "#links" do
 			it "finds no links in the root directory" do
-				@root.links.should have(0).items
+				@root.links.size.should be(0)
 			end
 
 			it "finds 1 link in directory <d1>" do
-				(@root / 'd1').links.should have(1).item
+				(@root / 'd1').links.size.should eq(1)
 			end
 		end
 	end

--- a/spec/filepathlist_spec.rb
+++ b/spec/filepathlist_spec.rb
@@ -14,7 +14,7 @@ describe FilepathList do
 			paths = %w{a/b c/d e/f}
 			list = FilepathList.new(paths)
 
-			list.should have(3).items
+			list.size.should eq(3)
 			list.each { |path| path.should be_a(Filepath) }
 		end
 
@@ -22,7 +22,7 @@ describe FilepathList do
 			paths = %w{a/b c/d e/f}.map(&:as_path)
 			list = FilepathList.new(paths)
 
-			list.should have(3).items
+			list.size.should eq(3)
 			list.each { |path| path.should be_a(Filepath) }
 		end
 
@@ -30,7 +30,7 @@ describe FilepathList do
 			paths = [%w{a b}, %w{c d}, %w{e f}]
 			list = FilepathList.new(paths)
 
-			list.should have(3).items
+			list.size.should eq(3)
 			list.each { |path| path.should be_a(Filepath) }
 		end
 	end
@@ -49,7 +49,7 @@ describe FilepathList do
 			list2 = FilepathList.new(%w{d e})
 
 			list = list1 + list2
-			list.should have(5).items
+			list.size.should eq(5)
 			list[0].should eq('a')
 			list[1].should eq('b')
 			list[2].should eq('c')
@@ -63,7 +63,7 @@ describe FilepathList do
 			list1 = FilepathList.new(%w{a/b /a/c e/d})
 			list2 = list1 - %w{a/b e/d}
 
-			list2.should have(1).item
+			list2.size.should eq(1)
 			list2[0].should eq('/a/c')
 		end
 	end
@@ -73,8 +73,8 @@ describe FilepathList do
 			list1 = FilepathList.new(%w{a/b /c/d})
 			list2 = list1 << "e/f"
 
-			list1.should have(2).items
-			list2.should have(3).items
+			list1.size.should eq(2)
+			list2.size.should eq(3)
 
 			list2[0].should eq('a/b')
 			list2[1].should eq('/c/d')
@@ -93,7 +93,7 @@ describe FilepathList do
 				all_paths = p1.product(p2).map { |x| x.join('/') }
 
 				list = list1 * list2
-				list.should have(6).items
+				list.size.should eq(6)
 				list.should include(*all_paths)
 			end
 
@@ -102,7 +102,7 @@ describe FilepathList do
 				p2 = "abc"
 
 				list = FilepathList.new(p1) * p2
-				list.should have(3).items
+				list.size.should eq(3)
 				list.should include(*%w{a/abc b/abc c/abc})
 			end
 
@@ -111,7 +111,7 @@ describe FilepathList do
 				p2 = Filepath.new("x")
 
 				list = FilepathList.new(p1) * p2
-				list.should have(3).items
+				list.size.should eq(3)
 				list.should include(*%w{a/x b/x c/x})
 			end
 
@@ -120,7 +120,7 @@ describe FilepathList do
 				p2 = ["1", "2"]
 
 				list = FilepathList.new(p1) * p2
-				list.should have(6).items
+				list.size.should eq(6)
 				list.should include(*%w{a/1 b/1 a/2 b/2 c/1 c/2})
 			end
 		end
@@ -131,7 +131,7 @@ describe FilepathList do
 			paths = %w{a/b/x1 a/b/x2 a/b/x3}
 			list = FilepathList.new(paths).remove_common_segments
 
-			list.should have(3).items
+			list.size.should eq(3)
 			list.should include(*%w{x1 x2 x3})
 		end
 
@@ -139,7 +139,7 @@ describe FilepathList do
 			list1 = FilepathList.new(%w{a/b/x1 a/b/c/x2 a/b/d/e/x3})
 			list2 = list1.remove_common_segments
 
-			list2.should have(3).items
+			list2.size.should eq(3)
 			list2.should include(*%w{x1 c/x2 d/e/x3})
 		end
 
@@ -197,21 +197,21 @@ describe FilepathList do
 		describe "#all?" do
 			it "checks whether a block applies to a list" do
 				ok = list.all? { |path| path.extension? }
-				ok.should be_true
+				ok.should be true
 			end
 		end
 
 		describe "#any?" do
 			it "check whether a block does not apply to any path" do
 				ok = list.any? { |path| path.basename == "a.foo" }
-				ok.should be_true
+				ok.should be true
 			end
 		end
 
 		describe "#none?" do
 			it "check whether a block does not apply to any path" do
 				ok = list.none? { |path| path.absolute? }
-				ok.should be_true
+				ok.should be true
 			end
 		end
 	end
@@ -224,14 +224,14 @@ describe FilepathList do
 				remaining = list.select(/bar$/)
 
 				remaining.should be_a FilepathList
-				remaining.should have(2).items
+				remaining.size.should eq(2)
 				remaining.each { |path| path.extension.should == 'bar' }
 			end
 
 			it "keeps all the paths for which the block returns true" do
 				remaining = list.select { |ph| ph.extension?('bar') }
 
-				remaining.should have(2).items
+				remaining.size.should eq(2)
 				remaining.each { |ph| ph.extension.should == 'bar' }
 			end
 		end
@@ -241,7 +241,7 @@ describe FilepathList do
 				remaining = list.exclude(/bar$/)
 
 				remaining.should be_a FilepathList
-				remaining.should have(3).items
+				remaining.size.should eq(3)
 				remaining.each { |path| path.extension.should == 'foo' }
 			end
 
@@ -249,7 +249,7 @@ describe FilepathList do
 				remaining = list.exclude { |path| path.extension?('bar') }
 
 				remaining.should be_a FilepathList
-				remaining.should have(3).items
+				remaining.size.should eq(3)
 				remaining.each { |path| path.extension.should == 'foo' }
 			end
 		end
@@ -259,8 +259,8 @@ describe FilepathList do
 				mapped = list.map { |path| path.remove_extension }
 
 				mapped.should be_a FilepathList
-				mapped.should have(list.size).items
-				mapped.each { |path| path.extension?.should be_false }
+				mapped.size.should eq(list.size)
+				mapped.each { |path| path.extension?.should be false }
 			end
 		end
 	end


### PR DESCRIPTION
This change proposes small changes in the syntax of the specs to make them compatible with RSpec 3.
- change be_true/be_false to be true/be false
- replace y.should have(n).items by y.size.should eq(n)
With these changes, the test pass with RSpec 3.3
(a version of) this patch is used by the Debian project.