### PR TITLE
Replace exists? by exist? (removed in ruby3.2)

### DIFF
--- a/lib/filepath/filepath.rb
+++ b/lib/filepath/filepath.rb
@@ -875,8 +875,8 @@ class Filepath
 
 		define_filetest_method :chardev?
 
-		define_filetest_method :exists?
-		alias :exist? :exists?
+		define_filetest_method :exist?
+		alias :exists? :exist?
 
 		define_filetest_method :readable?
 
@@ -941,7 +941,7 @@ class Filepath
 
 	module FilesystemTests
 		def mountpoint?
-			if !directory? || !exists?
+			if !directory? || !exist?
 				return false
 			end
 

--- a/spec/filepath_spec.rb
+++ b/spec/filepath_spec.rb
@@ -732,7 +732,7 @@ describe Filepath do
 		end
 
 		after(:each) do
-			File.delete(ph) if File.exists?(ph)
+			File.delete(ph) if File.exist?(ph)
 		end
 
 		describe "#touch" do
@@ -790,7 +790,7 @@ describe Filepath do
 		end
 
 		after(:each) do
-			File.delete(ph) if File.exists?(ph)
+			File.delete(ph) if File.exist?(ph)
 		end
 
 		describe "#read" do
@@ -874,7 +874,7 @@ describe Filepath do
 		end
 
 		after(:each) do
-			File.delete(ph) if File.exists?(ph)
+			File.delete(ph) if File.exist?(ph)
 		end
 
 		describe "#open" do
@@ -957,7 +957,7 @@ describe Filepath do
 		end
 
 		after(:each) do
-			File.delete(ph) if File.exists?(ph)
+			File.delete(ph) if File.exist?(ph)
 		end
 
 		describe "#empty?" do


### PR DESCRIPTION
The method `exists?` has been deprecated since ruby2.4, and removed in ruby3.2. This patch is replacing `exists?` by `exist?`, but still creates an alias `exists?` for MetadataTests for compatibility reasons.